### PR TITLE
Changes for initial installation

### DIFF
--- a/fieldpick/frametools.py
+++ b/fieldpick/frametools.py
@@ -66,7 +66,7 @@ def save_frame(frame, save_file):
     else:
         existing_content = None
 
-    if existing_content.equals(frame):
+    if existing_content is not None and existing_content.equals(frame):
         logger.info(f"Skipping save of {file_path} - no changes")
         return
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ locket==1.0.0
 MarkupSafe==2.1.2
 mypy-extensions==0.4.3
 natsort==8.2.0
-numpy==1.23.5
+numpy==1.26.4
 oauth2client==4.1.3
 oauthlib==3.2.2
 packaging==23.0


### PR DESCRIPTION
Two changes to make the instructions from the readme run correctly:

```
source .venv/bin/activate
pip install -r requirements.txt
```

This PR updates numpy to 1.26 because 1.23 no longer works with Python 3.12 (See https://github.com/numpy/numpy/issues/23808)

```
python fieldpick/create-teams.py
```

This PR adds a None check to prevent `create-teams.py` from crashing on its initial run.